### PR TITLE
add detection of OP_RETURN and P2MS CounterParty transactions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ categories = ["cryptography::cryptocurrencies"]
 bitcoin = "0.27"
 secp256k1 = "0.19.0"
 hex = "0.4"
+rc4 = { version = "0.1.0", optional = true }
+
+[features]
+default = []
+# used to detect counterparty transactions
+counterparty = [ "dep:rc4" ]

--- a/src/input.rs
+++ b/src/input.rs
@@ -139,8 +139,8 @@ pub trait ScriptHashInput {
 }
 
 impl ScriptHashInput for TxIn {
-    // returns the redeem script of the input. The caller must make sure the
-    // input is script hash based, otherwise None is returned.
+    /// Returns the redeem script of the input. The caller must make sure the
+    /// input is script hash based, otherwise None is returned.
     fn redeem_script(&self) -> Result<Option<bitcoin::Script>, script::Error> {
         if !self.is_scripthash_input()? {
             return Ok(None);

--- a/src/output.rs
+++ b/src/output.rs
@@ -131,7 +131,7 @@ impl OutputTypeDetection for TxOut {
 
     /// Checks if an output pays to a P2MS script.
     ///
-    /// A P2MS output as a standard OP_CHECKMULTSIG template as usually seen in
+    /// A P2MS output has a standard OP_CHECKMULTSIG template as usually seen in
     /// e.g. P2SH redeemscripts as script_pubkey. N and M (n-of-m) can't be
     /// bigger than 3 and m must be bigger than or equal to n;
     /// `script_pubkey: [ <OP_PUSHNUM_N>   M * <pubkey>   <OP_PUSHNUM_M> <OP_CHECKMULTISIG> ]`

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -115,7 +115,7 @@ impl TxInfo {
         self.input_infos.iter().any(|i| i.is_spending_multisig())
     }
 
-    /// Returns true if at least one input spends native SegWit.
+    /// Returns true if at the inputs and outputs are sorted according to BIP-69.
     pub fn is_bip69_compliant(&self) -> bool {
         self.is_bip69_compliant
     }


### PR DESCRIPTION
This adds detection of OP_RETURN and P2MS CounterParty transactions. CounterParty usage is hidden by encrypting the payload with the txid of the first input with Rc4. An optional dependency on RC4 is introduced and gated with the `counterparty` feature.