### PR TITLE
improve and fix checks for coinbase transactions

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -706,27 +706,21 @@ impl InputTypeDetection for TxIn {
     /// A coinbase has a an Outpoint with an all zero txid and an output index
     /// of 0xffffffff. The witness is empty.
     fn is_coinbase(&self) -> bool {
-        if self.has_witness()
-            || self.previous_output.vout != 0xffffffff
-            || !self.previous_output.is_null()
-        {
-            return false;
-        }
-        true
+        !self.has_witness()
+            && self.previous_output.vout == 0xffffffff
+            && self.previous_output.is_null()
     }
 
-    /// Checks if an input is a coinbase with witness data. // TODO: since when are these to be expected?
+    /// Checks if an input is a coinbase with witness data. On mainnet, this
+    /// input type is expected after SegWit activation at height 481824
+    /// (24 August 2017).
     ///
     /// A coinbase has a an Outpoint with an all zero txid and an output index
     /// of 0xffffffff. The witness is not empty.
     fn is_coinbase_witness(&self) -> bool {
-        if !self.has_witness()
-            || self.previous_output.vout != 0xffffffff
-            || !self.previous_output.is_null()
-        {
-            return false;
-        }
-        true
+        self.has_witness()
+            && self.previous_output.vout == 0xffffffff
+            && self.previous_output.is_null()
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -288,7 +288,7 @@ mod tests {
         assert!(out0.is_p2ms());
         assert_eq!(out0.get_type(), OutputType::P2ms);
     }
-    
+
     #[test]
     fn output_type_detection_p2ms2() {
         // mainnet d5a02fd4d7e3cf5ca02d2a4c02c8124ba00907eb85801dddfe984428714e3946
@@ -298,7 +298,6 @@ mod tests {
         assert!(out0.is_p2ms());
         assert_eq!(out0.get_type(), OutputType::P2ms);
     }
-
 
     #[test]
     fn output_type_detection_p2tr() {

--- a/src/script.rs
+++ b/src/script.rs
@@ -457,7 +457,6 @@ impl Multisig for bitcoin::Script {
             return Ok(None);
         }
 
-        
         // Normally, the instructions between OP_PUSHNUM_N and OP_PUSHNUM_M should be public keys.
         // However, these data pushes are sometimes used to store arbitraity data in P2MS output.
         // They are still multisig n-of-m's.
@@ -493,25 +492,19 @@ mod tests {
             Ok(Some((2, 2)))
         )
     }
-    
+
     #[test]
     fn multisig_opcheckmultisig_1of3() {
         // from mainnet d5a02fd4d7e3cf5ca02d2a4c02c8124ba00907eb85801dddfe984428714e3946 output 0
         let p2ms_output_1of3 = ScriptBuf::from_hex("512102d7f69a1fc373a72468ae84634d9949fdeab4d1c903c6f23a3465f79c889342a421028836687b0c942c94801ce11b2601cbb1e900e6544ef28369e69977195794d47b2102dc6546ba58b9bc26365357a428516d48c9bbc230dd6fc72912654aaad460ef1953ae").unwrap();
-        assert_eq!(
-            p2ms_output_1of3.get_opcheckmultisig_n_m(),
-            Ok(Some((1, 3)))
-        )
+        assert_eq!(p2ms_output_1of3.get_opcheckmultisig_n_m(), Ok(Some((1, 3))))
     }
-    
+
     #[test]
     fn multisig_opcheckmultisig_1of3_2() {
         // from mainnet 6e45ba2e4f71497291170c40e7161fb47675ff0a7d6c67c1fda485832ed7c923 output 1
         let p2ms_output_1of3 = ScriptBuf::from_hex("5121027f86d68a007dc5c214c67f964350136c69fa5c783f70b9e7e13935b3f4a1c60e21032e6d71977d2685a41eecdfc260c2463903bef6cc83eaaa77555d90ea7ba09e7a2103030303030303030303030303030303030303030303030303030303030303030353ae").unwrap();
-        assert_eq!(
-            p2ms_output_1of3.get_opcheckmultisig_n_m(),
-            Ok(Some((1, 3)))
-        )
+        assert_eq!(p2ms_output_1of3.get_opcheckmultisig_n_m(), Ok(Some((1, 3))))
     }
 
     #[test]


### PR DESCRIPTION
Primarily, do the (cheap) checks for a coinbase(_witness) transaction first as some of the coinbase transactions might have weird input scripts that we otherwise could error on. Also adds a test case for this and improves the readability of the is_coinbase() functions. 