### PR TITLE
Misc cleanups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Check formatting
       run: cargo fmt --check
     - name: Check clippy suggestions

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,5 @@ pkgs.mkShell {
       pkgs.cargo
       pkgs.rustfmt
       pkgs.rustc
-      pkgs.clang_15
     ];
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -827,8 +827,8 @@ impl InputInscriptionDetection for TxIn {
             return Ok(false);
         }
         // Inscription reveals can be identified by inspecting the tapscript
-        if let Some(tapscript) = self.witness.tapscript() {
-            if let Ok(instructions) = instructions_as_vec(tapscript) {
+        if let Some(tapscript) = self.witness.taproot_leaf_script() {
+            if let Ok(instructions) = instructions_as_vec(tapscript.script) {
                 let mut instruction_iter = instructions.iter();
                 while let Some(instruction) = instruction_iter.next() {
                     if matches!(instruction, Instruction::PushBytes(bytes) if bytes.is_empty())

--- a/src/input.rs
+++ b/src/input.rs
@@ -776,7 +776,7 @@ impl InputTypeDetection for TxIn {
 
         // check for control block
         let control_block = &witness_vec[control_block_index];
-        if control_block.len() < 1 + 32 || (control_block.len() - 1) % 32 != 0 {
+        if control_block.len() < 1 + 32 || !(control_block.len() - 1).is_multiple_of(32) {
             return false;
         }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -25,7 +25,7 @@ const ECDSA_SIG_MAX_STRICT_DER_LEN: usize = 73;
 // `Vec<script::Instruction>` for easier handling.
 pub fn instructions_as_vec(
     script: &bitcoin::Script,
-) -> Result<Vec<script::Instruction>, script::Error> {
+) -> Result<Vec<script::Instruction<'_>>, script::Error> {
     script
         .instructions()
         .collect::<Result<Vec<script::Instruction>, script::Error>>()


### PR DESCRIPTION
Cleaning up some compile and clippy warnings. Also, remove clang_15 from shell.nix. It's deprecated and not needed.