### PR TITLE
fix: skip annex when collecting signatures from P2TR script-path spends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bitcoin", "transaction", "information"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-bitcoin = "0.32"
+bitcoin = "0.32.6"
 hex = "0.4"
 rc4 = { version = "0.1.0", optional = true }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -738,17 +738,11 @@ impl InputTypeDetection for TxIn {
         if !self.script_sig.is_empty() || !self.has_witness() || self.witness.len() > 2 {
             return false;
         }
-        if self.witness.len() == 1 {
-            // without annex
+
+        if self.witness.len() == 1 || self.witness.taproot_annex().is_some() {
             return self.witness.to_vec()[0].is_schnorr_signature();
-        } else if self.witness.len() == 2 {
-            // with annex
-            if !self.witness.to_vec()[1].is_empty()
-                && self.witness.to_vec()[1][0] == TAPROOT_ANNEX_INDICATOR
-            {
-                return self.witness.to_vec()[0].is_schnorr_signature();
-            }
         }
+
         false
     }
 
@@ -763,19 +757,10 @@ impl InputTypeDetection for TxIn {
             return false;
         }
 
-        let last_witness_element_index = self.witness.len() - 1;
-        let mut control_block_index = last_witness_element_index;
-        let witness_vec = self.witness.to_vec();
-
-        // check for annex
-        if !witness_vec[last_witness_element_index].is_empty()
-            && witness_vec[last_witness_element_index][0] == TAPROOT_ANNEX_INDICATOR
-        {
-            control_block_index -= 1;
-        }
-
-        // check for control block
-        let control_block = &witness_vec[control_block_index];
+        let control_block = match self.witness.taproot_control_block() {
+            Some(control_block) => control_block,
+            None => return false,
+        };
         if control_block.len() < 1 + 32 || !(control_block.len() - 1).is_multiple_of(32) {
             return false;
         }
@@ -1045,6 +1030,49 @@ mod tests {
         assert_eq!(in0.get_type().unwrap(), InputType::P2trkp);
         assert!(InputInfo::new(in0).unwrap().is_spending_taproot());
         assert!(InputInfo::new(in0).unwrap().is_spending_segwit());
+    }
+
+    #[test]
+    fn p2trkp_input_detection_with_annex() {
+        use bitcoin::{OutPoint, ScriptBuf, Sequence, TxIn, Witness};
+
+        let sig = vec![0u8; 64];
+        let annex = vec![0x50u8, 0x00u8];
+        let witness = Witness::from_slice(&[sig.as_slice(), annex.as_slice()]);
+        let txin = TxIn {
+            previous_output: OutPoint::new(
+                bitcoin::Txid::from_raw_hash(bitcoin::hashes::Hash::from_byte_array([1u8; 32])),
+                0,
+            ),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness,
+        };
+
+        assert!(txin.is_p2trkp());
+        assert_eq!(txin.get_type().unwrap(), InputType::P2trkp);
+    }
+
+    #[test]
+    fn p2trsp_input_detection_rejects_two_item_annex() {
+        use bitcoin::{OutPoint, ScriptBuf, Sequence, TxIn, Witness};
+
+        let mut control_block = vec![0xc0u8];
+        control_block.extend_from_slice(&[0u8; 32]);
+        let annex = vec![0x50u8, 0x00u8];
+        let witness = Witness::from_slice(&[control_block.as_slice(), annex.as_slice()]);
+        let txin = TxIn {
+            previous_output: OutPoint::new(
+                bitcoin::Txid::from_raw_hash(bitcoin::hashes::Hash::from_byte_array([1u8; 32])),
+                0,
+            ),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness,
+        };
+
+        assert!(!txin.is_p2trsp());
+        assert_ne!(txin.get_type().unwrap(), InputType::P2trsp);
     }
 
     #[test]

--- a/src/script.rs
+++ b/src/script.rs
@@ -544,7 +544,16 @@ impl SignatureInfo {
                 // P2TR script-path spends contain zero or multiple signatures in the witness.
                 // There can't be any signatures in the annex, control block or script part.
                 // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
-                for bytes in input.witness.to_vec()[..input.witness.len() - 2].iter() {
+                //
+                // Drop the script + control block, plus the annex when present.
+                let to_drop = if input.witness.taproot_annex().is_some() {
+                    3
+                } else {
+                    2
+                };
+                let witness_vec = input.witness.to_vec();
+                let stack_end = witness_vec.len() - to_drop;
+                for bytes in witness_vec[..stack_end].iter() {
                     if let Some(signature_info) = SignatureInfo::from_u8_slice_schnorr(bytes) {
                         signature_infos.push(signature_info);
                     }
@@ -1222,5 +1231,48 @@ mod tests {
             assert!(s.is_ecdsa_signature(testcase.der_encoded == DEREncoding::Valid));
             assert!(!s.is_schnorr_signature());
         }
+    }
+
+    /// Regression test: P2TR script-path spends with an annex must skip the
+    /// annex *and* the script when collecting signatures. Slicing
+    /// `witness[..len-2]` unconditionally would include the script item,
+    /// which can be miscounted as a Schnorr signature when its serialised
+    /// length happens to be 64 or 65 bytes.
+    #[test]
+    fn signature_info_all_from_p2trsp_with_annex() {
+        use crate::input::InputTypeDetection;
+        use bitcoin::{OutPoint, Sequence, TxIn, Witness};
+
+        // Witness layout: [ sig, script (64 bytes), control_block, annex ]
+        let sig = vec![0u8; 64];
+        let script = vec![0u8; 64];
+        let mut control_block = vec![0xc0u8];
+        control_block.extend_from_slice(&[0u8; 32]);
+        let annex = vec![0x50u8, 0x00u8];
+
+        let witness = Witness::from_slice(&[
+            sig.as_slice(),
+            script.as_slice(),
+            control_block.as_slice(),
+            annex.as_slice(),
+        ]);
+
+        let txin = TxIn {
+            previous_output: OutPoint::new(
+                bitcoin::Txid::from_raw_hash(bitcoin::hashes::Hash::from_byte_array([1u8; 32])),
+                0,
+            ),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness,
+        };
+
+        assert_eq!(txin.get_type().unwrap(), crate::input::InputType::P2trsp);
+        let sigs = super::SignatureInfo::all_from(&txin).unwrap();
+        assert_eq!(
+            sigs.len(),
+            1,
+            "annex must be excluded; only the actual signature should be counted"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`SignatureInfo::all_from` sliced a P2TR script-path witness as `witness[..len - 2]` to drop the script and control block before scanning the rest for Schnorr signatures. That layout assumption breaks when an annex is present: per BIP-341 the layout becomes `[stack..., script, control_block, annex]`, so the slice included the script. If the script is 64 bytes (or 65 bytes ending in a valid sighash flag), `is_schnorr_signature` (a structural length check, not cryptographic, `src/script.rs:155-167`) accepts it and the script is miscounted as a signature.

The conditions for this to fire are narrow (annex present, script with that specific length, and for 65-byte scripts a terminal byte that matches a sighash flag), but the count is still wrong whenever those conditions hold.

The fix detects the annex with `bitcoin::Witness::taproot_annex()` and drops three trailing items instead of two when present. `InputTypeDetection::is_p2trsp` now uses `Witness::taproot_control_block()` so a two-item witness shaped like `[control_block, annex]` is not classified as P2TR script-path: after removing the annex, BIP-341 requires at least `[script, control_block]` to remain for a consensus-valid P2TR script-path spend. With that classifier invariant in place, `all_from` can use a normal `len() - to_drop` slice boundary.

The same commit replaces the duplicated manual annex-prefix checks in `is_p2trkp` and `is_p2trsp` with the upstream witness helpers, keeping annex interpretation consistent across classification and signature collection.

The `bitcoin` dependency floor moves from `"0.32"` to `"0.32.6"`. `Witness::taproot_annex()` landed in 0.32.4 and `Witness::taproot_leaf_script()` (already used on master since `24ca87f`) in 0.32.6, so the previous loose requirement let minimal-version builds pick a release missing both helpers.

Noticed while reviewing #40, whose `InputSigChecks::sig_checks` handles the annex inline; `all_from` (which feeds the public `InputInfo::signature_info`) silently kept the buggy slice. Fixing `all_from` is a prerequisite if we want to collapse `sig_checks` to `Ok(SignatureInfo::all_from(self)?.len())`.

## Testing

- `cargo test`: 52 unit + 2 doc tests pass; `cargo clippy` clean.
- `signature_info_all_from_p2trsp_with_annex`: synthetic witness with a 64-byte script (matches the `is_schnorr_signature` length check); returns 1 with the fix, 2 without (verified by reverting the patch).
- `p2trsp_input_detection_rejects_two_item_annex`: malformed `[control_block, annex]` witness is no longer classified as P2TR script-path.
- `p2trkp_input_detection_with_annex`: refactored key-path annex path.
- Dependency floor verified: `cargo update -p bitcoin --precise 0.32.6` builds and tests pass.